### PR TITLE
fix: implement safe lucide icons plugin for error handling

### DIFF
--- a/apps/docs/src/lib/safe-lucide-icons-plugin.ts
+++ b/apps/docs/src/lib/safe-lucide-icons-plugin.ts
@@ -1,0 +1,49 @@
+import { createElement, type ReactNode } from "react";
+import { icons } from "lucide-react";
+import { type LoaderPlugin } from "fumadocs-core/source";
+
+export const safeLucideIconsPlugin = (
+  options: { defaultIcon?: keyof typeof icons } = {},
+): LoaderPlugin => {
+  const { defaultIcon = "FileQuestionMark" } = options;
+
+  const resolveIcon = (icon: unknown): ReactNode => {
+    if (!icon || typeof icon !== "string") return icon as ReactNode;
+
+    const Icon = icons[icon as keyof typeof icons];
+    if (Icon) {
+      return createElement(Icon);
+    }
+
+    console.warn(
+      `[safe-lucide-icons] ⚠️ Icon "${icon}" not found. Falling back to "${defaultIcon}".`,
+    );
+
+    return createElement(icons[defaultIcon]);
+  };
+
+  return {
+    name: "safe-lucide-icons",
+    transformStorage({ storage }) {
+      for (const file of storage.files.values()) {
+        if (file.format === "page") {
+          file.data.icon = resolveIcon(file.data.icon) as any;
+        }
+      }
+    },
+    transformPageTree: {
+      file: (node) => {
+        node.icon = resolveIcon(node.icon);
+        return node;
+      },
+      folder: (node) => {
+        node.icon = resolveIcon(node.icon);
+        return node;
+      },
+      separator: (node) => {
+        node.icon = resolveIcon(node.icon);
+        return node;
+      },
+    },
+  };
+};

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -1,13 +1,14 @@
 import { type InferPageType, loader, type LoaderPlugin } from 'fumadocs-core/source';
-import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
 import { openapiPlugin } from 'fumadocs-openapi/server';
+
+import { safeLucideIconsPlugin } from './safe-lucide-icons-plugin';
 import { docs } from '@/.source';
 
 // See https://fumadocs.dev/docs/headless/source-api for more info
 export const source = loader({
   baseUrl: '/docs',
   source: docs.toFumadocsSource(),
-  plugins: [lucideIconsPlugin(), openapiPlugin() as LoaderPlugin],
+  plugins: [safeLucideIconsPlugin(), openapiPlugin() as LoaderPlugin],
 });
 
 export const getPageImage = (page: InferPageType<typeof source>) => {


### PR DESCRIPTION
issue: https://github.com/wallwhite/hyperion-docs/issues/7